### PR TITLE
Develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,13 @@ ASM_SOURCES  := $(shell find $(CUBE_DIR) -name "*.s")
 C_SOURCES    := $(shell find src -name "*.c")
 C_HEADERS    := $(shell find inc -name "*.h")
 LIB_SOURCES  :=
+
+ifeq ($(TEST), 1)
 TEST_HEADERS := $(shell find $(TEST_DIR)/inc -name "*.h")
+else
+TEST_HEADERS :=
+endif
+
 TEST_SOURCES := $(shell find $(TEST_DIR)/src -name "*.c")
 
 ifeq ($(TEST), 1)

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,7 @@ C_SOURCES    := $(shell find src -name "*.c")
 C_HEADERS    := $(shell find inc -name "*.h")
 LIB_SOURCES  :=
 
-ifeq ($(TEST), 1)
 TEST_HEADERS := $(shell find $(TEST_DIR)/inc -name "*.h")
-else
-TEST_HEADERS :=
-endif
-
 TEST_SOURCES := $(shell find $(TEST_DIR)/src -name "*.c")
 
 ifeq ($(TEST), 1)

--- a/README.md
+++ b/README.md
@@ -113,9 +113,16 @@ LIB_DIR  := lib
 # Cube Directory
 CUBE_DIR := cube
 
+# Config Files Directory
+CFG_DIR :=
+
+# Tests Directory
+TEST_DIR := tests
+
 # Default values, can be set on the command line or here
 DEBUG   ?= 1
 VERBOSE ?= 0
+TEST    ?= 0
 ```
 
 ## Compilando
@@ -167,7 +174,9 @@ opções da lista para executar os comandos de compilação e gravação mais ra
 * Flash Program (_make flash_)
 * Build and Flash (_make && make flash_)
 
-## Adicionando um submódulo
+## Submódulos
+
+### Adicionando um submódulo
 
 Crie um diretório chamado `lib` e adicione o submódulo nele.
 
@@ -177,6 +186,28 @@ Exemplo:
 mkdir lib
 git submodule add --name STMSensors git@github.com:ThundeRatz/STMSensors.git lib/STMSensors
 ```
+
+### Inicializando um submódulo já existente
+
+Ao clonar um repositório que já tem submóluos, é necessário clonar os repositórios desse submódulo. Isso pode ser feito de duas formas, clonando junto com o repositório do projeto ou depois de já ter clonado.
+
+Exemplo:
+
+Para se clonar junto, deve-se fazer:
+
+```bash
+git clone --recurse-submodules git@github.com:ThundeRatz/STM32ProjectTemplate.git
+```
+
+Para se clonar depois de já ter clonado o repositório do projeto:
+
+```bash
+git submodule update --init
+```
+
+## Diretório de testes
+
+O diretório definido pela variável `TEST_DIR` contém arquivos para testes de partes específicas do projeto, separando isso do código do proejto em si. Esses arquivos devem ser implementados de acordo com as necessidades dos desenvolvedores. O diretório contém uma função `main()` própria. Para se fazer os testes com esses arquivos, compilá-los e gravar o executável gerado, deve-se mudar o valor da variável `TEST` para 1.
 
 ## Debug
 


### PR DESCRIPTION
Resolve warning do Makefile quando não se tem arquivos de teste e atualiza o README com informações sobre os submódulos e sobre o diretório de testes.