### PR TITLE
Use bundled JRE to generate cube files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,11 @@ $(BUILD_DIR):
 
 ifeq ($(OS),Windows_NT)
 CUBE_JAR  := "$(CUBE_PATH)\STM32CubeMX.exe"
+JAVA_EXE  := "$(CUBE_PATH)\jre\bin\java"
 JLINK_EXE := JLink.exe
 else
 CUBE_JAR  := "$(CUBE_PATH)/STM32CubeMX"
+JAVA_EXE  := "$(CUBE_PATH)/jre/bin/java"
 JLINK_EXE := JLinkExe
 endif
 
@@ -266,6 +268,9 @@ endif
 
 # Generate Cube Files
 cube: .cube
+	$(AT)$(JAVA_EXE) -jar $(CUBE_JAR) -q $<
+
+cube_old: .cube
 	$(AT)java -jar $(CUBE_JAR) -q $<
 
 # Prepare workspace

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ $(BUILD_DIR):
 
 ifeq ($(OS),Windows_NT)
 CUBE_JAR  := "$(CUBE_PATH)\STM32CubeMX.exe"
-JAVA_EXE  := "$(CUBE_PATH)\jre\bin\java"
+JAVA_EXE  := "$(CUBE_PATH)\jre\bin\java.exe"
 JLINK_EXE := JLink.exe
 else
 CUBE_JAR  := "$(CUBE_PATH)/STM32CubeMX"


### PR DESCRIPTION
Com essas mudanças, o target `cube` do makefile passa a usar a jre que vem junto com a instalação do CubeMX, em vez de depender de uma instalação externa. Para deixar compatível com versões anteriores, tem o target `cube_old`, que é exatamente o mesmo de antes.

Funcionou certinho com a versão 6.3 do Cube no Ubuntu 20.04, agora preciso de alguém para testar no Windows também uahsuauhsa

Tava pensando em já atualizar aqui a versão do .ioc para 6.3, e ai forçar todo mundo a atualizar o cube. Não commitei ainda para quem tiver a versão 6.2 poder testar e ver se precisa mesmo do `cube_old`, mas antes de mergear já aproveito essa PR pra fazer isso