### PR TITLE
🩹 Add include guard on test core header

### DIFF
--- a/tests/inc/test_core.h
+++ b/tests/inc/test_core.h
@@ -1,7 +1,7 @@
 /**
- * @file tests_core.h
+ * @file test_core.h
  *
- * @brief Core functions to the tests
+ * @brief Core functions to the test
  *
  * @date 04/2021
  *
@@ -9,17 +9,17 @@
  *
  */
 
-#ifndef __TESTS_CORE_H__
-#define __TESTS_CORE_H__
+#ifndef __TEST_CORE_H__
+#define __TEST_CORE_H__
 
 /*****************************************
  * Public Functions Prototypes
  *****************************************/
 
 /**
- * @brief Initialize tests core
+ * @brief Initialize test core
  *
  */
 void test_core_init(void);
 
-#endif // __TESTS_CORE_H__
+#endif // __TEST_CORE_H__

--- a/tests/inc/tests_core.h
+++ b/tests/inc/tests_core.h
@@ -9,6 +9,9 @@
  *
  */
 
+#ifndef __TESTS_CORE_H__
+#define __TESTS_CORE_H__
+
 /*****************************************
  * Public Functions Prototypes
  *****************************************/
@@ -18,3 +21,5 @@
  *
  */
 void test_core_init(void);
+
+#endif // __TESTS_CORE_H__

--- a/tests/src/test_core.c
+++ b/tests/src/test_core.c
@@ -1,7 +1,7 @@
 /**
- * @file tests_core.c
+ * @file test_core.c
  *
- * @brief Core functions to the tests
+ * @brief Core functions to the test
  *
  * @date 04/2021
  *
@@ -9,7 +9,7 @@
  *
  */
 
-#include "tests_core.h"
+#include "test_core.h"
 #include "mcu.h"
 
 /*****************************************


### PR DESCRIPTION
Na hora de fazer o `test_core.h` faltou o include guard, como ele só era incluído uma vez em cada executável não dava problema, mas o melhor é ter.