### PR TITLE
🔨 Adicionando o necessário para usar a lib stm32handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,13 @@ As seguintes configurações não precisam ser alteradas, elas definem nomes de 
 ```Makefile
 # Lib dir
 LIB_DIR  := lib
+LIB_HANDLERS :=
 
 # Cube Directory
 CUBE_DIR := cube
 
 # Config Files Directory
-CFG_DIR :=
+CFG_DIR := cfg
 
 # Tests Directory
 TEST_DIR := tests
@@ -121,7 +122,9 @@ TEST_DIR := tests
 # Default values, can be set on the command line or here
 DEBUG   ?= 1
 VERBOSE ?= 0
-TEST    ?= 0
+VERBOSE ?= 0
+
+TEST_NAME ?=
 ```
 
 ## Compilando

--- a/config.mk
+++ b/config.mk
@@ -22,6 +22,7 @@ DEVICE_LD_FILE := STM32F303RETx_FLASH
 
 # Lib dir
 LIB_DIR  := lib
+LIB_HANDLERS :=
 
 # Cube Directory
 CUBE_DIR := cube
@@ -36,4 +37,4 @@ TEST_DIR := tests
 DEBUG   ?= 1
 VERBOSE ?= 0
 
-TEST_NAME ?= 
+TEST_NAME ?=


### PR DESCRIPTION
Como já foi discutido um tempo atrás no fórum, seria legall ter uma library com uma série de handler de embarcados fáceis de serem usados no dia a dia dos projetos.
Para isso, começamos a fazer uma lib para isso no repositório:
https://github.com/ThundeRatz/STM32Handler

De maneira geral, muita pouca coisa é modificada para usar essa branch, como era planejado. A priori, eu preferi deixar que as pessoas escolham exatamente quais handlers querem usar da lib. Sem isso, eles nem devem ser reconhecidos em includes.

Um exemplo de aplicação da lib está nessa branch da TPM-Galena: 
https://github.com/ThundeRatz/TPM-Galena/tree/feature/stm32handler 