### PR TITLE
🐛 Fix jflash command dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ $(VSCODE_FOLDER):
 -include $(wildcard $(BUILD_DIR)/**/*.d)
 
 .PHONY:                                                                    \
-	all cube prepare flash load jflash info reset clean_cube               \
+	all cube prepare flash load .jlink-flash jflash info reset clean_cube  \
 	clean clean_all format help vs_files rtt vs_launch vs_c_cpp_properties
 
 .DEFAULT_GOAL := all


### PR DESCRIPTION
Tinha um problema com o `jflash` que fazia com que o comando só funcionasse uma vez ao testar com múltiplos arquivos de teste, pois o arquivo `.jlink-flash` não era gerado de novo.