### PR TITLE
Adiciona integração com LSPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ cube/*
 !**/*.ioc
 
 build/
+.cache/
 -g
 .jlink-flash
 .cube

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ set(CMAKE_C_STANDARD 11)
 # @see: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
 set(CMAKE_BUILD_TYPE Debug)
 
+# Generate compile_commands.json for compatibility with LSPs
+# @see: https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Cube file name without .ioc extension
 project(stm32_project_template C ASM)
 


### PR DESCRIPTION
tl;dr
Adiciona `compile_commands.json` na geração do CMake pra integração com `LSP`

---

Como alguns sabem, recentemente comecei a usar nvim (btw), e uma coisa que se tornou um problema muito rapidamente foi lidar com [LSPs](https://en.wikipedia.org/wiki/Language_Server_Protocol), warnings e erros no editor.

![errors](https://github.com/ThundeRatz/STM32ProjectTemplate/assets/34964398/7ef1d402-0b5d-44d7-bd1c-de5e5d0a30e0)

Pesquisando sobre isso eu encontrei a opção [`CMAKE_EXPORT_COMPILE_COMMANDS`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html), que cria um arquivo chamado `compile_commands.json` na pasta de build do projeto, que contém as informações sobre os comandos de compilação, o que o LSP usa pra se guiar.

Olhando como isso é feito no VSCode, vi que a extensão do CMake builda usando essa opção também, olha só

![vscode](https://github.com/ThundeRatz/STM32ProjectTemplate/assets/34964398/02e54220-f2db-4262-a381-a2a5be1fc5a3)

No geral, essa opção vai deixar a minha vida (e de qualquer outro que use outro editor) muito mais fácil e não vai mudar nada na de vocês :p

Olha só como ficou mais agradável
![final](https://github.com/ThundeRatz/STM32ProjectTemplate/assets/34964398/23c1ee34-9b1d-48b7-a9a4-eaf91382c9c7)

---

Também adicionei a pasta `.cache` no `.gitignore`, que é criada pelo [`clangd`](https://clangd.llvm.org/) e também é usada pelo LSP.

---
texto gravemente copiado da [PR do Tracer](https://github.com/ThundeRatz/Tracer/pull/73)